### PR TITLE
Implemented a custom class for active sticky header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ion-sticky
 ***Super simple to use***
 
-Just add ion-sticky to ion-content, it will detect dividers and make the active one sticky. 
+Just add ion-sticky to ion-content, it will detect dividers and make the active one sticky.
 
 If you are using collection-repeat, please refer to this gist.
 
@@ -25,6 +25,21 @@ angular.module('ion-sticky-demo', ['ion-sticky']);
 
 ```html
 <ion-content ion-sticky>
+    <ion-list>
+        <ion-item class="item-divider"> A </ion-item>
+        <ion-item> A1 </ion-item>
+        <ion-item> A2 </ion-item>
+        ...
+        <ion-item class="item-divider"> B </ion-item>
+        ....
+    </ion-list>
+</ion-content>
+```
+
+Using custom style class for sticky header (default uses `assertive`):
+
+```html
+<ion-content ion-sticky ion-sticky-class="positive">
     <ion-list>
         <ion-item class="item-divider"> A </ion-item>
         <ion-item> A1 </ion-item>

--- a/ion-sticky.js
+++ b/ion-sticky.js
@@ -11,9 +11,9 @@ angular.module('ion-sticky', ['ionic'])
                     var result_textareas = to.getElementsByTagName('textarea');
                     var my_selects = original.getElementsByTagName('select');
                     var result_selects = to.getElementsByTagName('select');
-                    for (var i = 0, l = my_textareas.length; i < l; ++i) 
+                    for (var i = 0, l = my_textareas.length; i < l; ++i)
                         result_textareas[i].value = my_textareas[i].value;
-                    for (var i = 0, l = my_selects.length; i < l; ++i) 
+                    for (var i = 0, l = my_selects.length; i < l; ++i)
                         result_selects[i].value = my_selects[i].value;
                 };
                 // creates the sticky divider clone and adds it to DOM
@@ -24,8 +24,9 @@ angular.module('ion-sticky', ['ionic'])
                         left: 0,
                         right: 0
                     });
-                    cloneVal($element[0], clone[0])
-                    clone[0].className += " assertive";
+                    $attr.ionStickyClass = ($attr.ionStickyClass) ? $attr.ionStickyClass : 'assertive';
+                    cloneVal($element[0], clone[0]);
+                    clone[0].className += ' ' + $attr.ionStickyClass;
 
                     clone.removeAttr('ng-repeat-start').removeAttr('ng-if');
 
@@ -34,9 +35,9 @@ angular.module('ion-sticky', ['ionic'])
                     // compile the clone so that anything in it is in Angular lifecycle.
                     $compile(clone)($scope);
                 };
-               
+
                 var removeStickyClone = function () {
-                    if (clone) 
+                    if (clone)
                         clone.remove();
                     clone = null;
                 };
@@ -63,7 +64,7 @@ angular.module('ion-sticky', ['ionic'])
                             }
                         }
                     }
-    
+
                     if (lastActive != active) {
                         removeStickyClone();
                         lastActive = active;


### PR DESCRIPTION
This implements a second attribute `ion-sticky-class` for passing
a custom class to be applied on the active sticky header. if nothing
is passed it defaults to `assertive`.

updated README.md